### PR TITLE
discovery-sidecar: Check etcd process liveness

### DIFF
--- a/cmd/discovery-sidecar/main.go
+++ b/cmd/discovery-sidecar/main.go
@@ -23,6 +23,9 @@ import (
 // 4. (sidecar) Start DNS server and waiting for booting it.
 // 5. (etcd) Waiting for booting sidecar
 // 6. (etcd) Start etcd
+//
+// After started etcd, discovery-sidecar checks that the process is alive every second.
+// It detects process death, then it will be going to shutdown.
 
 func dnsSidecar(args []string) error {
 	fs := pflag.NewFlagSet("dns-sidecar", pflag.ContinueOnError)

--- a/container/BUILD.bazel
+++ b/container/BUILD.bazel
@@ -146,7 +146,6 @@ container_push(
 
 pkg_tar(
     name = "bin_sidecar",
-    srcs = ["//cmd/discovery-sidecar"],
     files = {
         "//cmd/discovery-sidecar:linux": "/usr/local/bin/discovery-sidecar",
     },

--- a/pkg/k8s/k8sfactory/core.go
+++ b/pkg/k8s/k8sfactory/core.go
@@ -171,6 +171,13 @@ func Subdomain(v string) Trait {
 	}
 }
 
+func ShareProcessNamespace(object any) {
+	switch obj := object.(type) {
+	case *corev1.Pod:
+		obj.Spec.ShareProcessNamespace = pointer.Bool(true)
+	}
+}
+
 func ContainerFactory(base *corev1.Container, traits ...Trait) *corev1.Container {
 	var c *corev1.Container
 	if base == nil {


### PR DESCRIPTION
discovery-sidecar: Check etcd process liveness

When the sidecar detects the process death, shutdown itself.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/22).
* __->__ #22
* #21
* #20
* #19
* #18
