### PR TITLE
k8s/api/proxy: Fix the bug that occurred the panic when ClisetSecretRef is nil

### DIFF
--- a/pkg/k8s/api/proxy/factory.go
+++ b/pkg/k8s/api/proxy/factory.go
@@ -156,6 +156,9 @@ func ClientSecret(name, key string) k8sfactory.Trait {
 		if !ok {
 			return
 		}
+		if p.Spec.IdentityProvider.ClientSecretRef == nil {
+			p.Spec.IdentityProvider.ClientSecretRef = &proxyv1alpha2.SecretSelector{}
+		}
 		p.Spec.IdentityProvider.ClientSecretRef.Name = name
 		p.Spec.IdentityProvider.ClientSecretRef.Key = key
 	}


### PR DESCRIPTION
k8s/api/proxy: Fix the bug that occurred the panic when ClisetSecretRef is nil

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/26).
* __->__ #26
* #25
* #24
