### PR TITLE
operator/e2e: Bump up the cluster version

### DIFF
--- a/operator/e2e/test/BUILD.bazel
+++ b/operator/e2e/test/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("//:RELEASE.bzl", "VERSION")
 
-K8S_CLUSTER_VERSION = "v1.22.0"
+K8S_CLUSTER_VERSION = "v1.25.3"
 
 go_test(
     name = "test_test",


### PR DESCRIPTION
operator/e2e: Bump up the cluster version

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/31).
* #32
* __->__ #31
* #30
* #29
