### PR TITLE
container: Force building the container for linux/amd64 regardless of host OS

### DIFF
--- a/cmd/heim-dashboard/BUILD.bazel
+++ b/cmd/heim-dashboard/BUILD.bazel
@@ -18,3 +18,11 @@ go_binary(
     embed = [":heim-dashboard_lib"],
     visibility = ["//visibility:public"],
 )
+
+go_binary(
+    name = "linux",
+    embed = [":heim-dashboard_lib"],
+    goos = "linux",
+    goarch = "amd64",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/heim-rpcserver/BUILD.bazel
+++ b/cmd/heim-rpcserver/BUILD.bazel
@@ -18,3 +18,11 @@ go_binary(
     embed = [":heim-rpcserver_lib"],
     visibility = ["//visibility:public"],
 )
+
+go_binary(
+    name = "linux",
+    embed = [":heim-rpcserver_lib"],
+    goos = "linux",
+    goarch = "amd64",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/heimctl/BUILD.bazel
+++ b/cmd/heimctl/BUILD.bazel
@@ -16,3 +16,11 @@ go_binary(
     embed = [":heimctl_lib"],
     visibility = ["//visibility:public"],
 )
+
+go_binary(
+    name = "linux",
+    goos = "linux",
+    goarch = "amd64",
+    embed = [":heimctl_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/heimdallr-proxy/BUILD.bazel
+++ b/cmd/heimdallr-proxy/BUILD.bazel
@@ -18,3 +18,11 @@ go_binary(
     embed = [":heimdallr-proxy_lib"],
     visibility = ["//visibility:public"],
 )
+
+go_binary(
+    name = "linux",
+    embed = [":heimdallr-proxy_lib"],
+    goarch = "amd64",
+    goos = "linux",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/heimdallrcontroller/BUILD.bazel
+++ b/cmd/heimdallrcontroller/BUILD.bazel
@@ -22,7 +22,7 @@ go_binary(
 go_binary(
     name = "linux",
     embed = [":heimdallrcontroller_lib"],
-    goarch = "amd64",
+    goarch = "arm64",
     goos = "linux",
     visibility = ["//visibility:public"],
 )

--- a/container/BUILD.bazel
+++ b/container/BUILD.bazel
@@ -5,11 +5,10 @@ load("//container:repo.bzl", "CONTAINER_IMAGE_REPOSITORIES", "REGISTRY")
 
 pkg_tar(
     name = "bin",
-    srcs = [
-        "//cmd/heimdallr-proxy",
-    ],
+    files = {
+      "//cmd/heimdallr-proxy:linux": "/usr/local/bin/heimdallr-proxy"
+    },
     mode = "0755",
-    package_dir = "/usr/local/bin",
 )
 
 container_image(
@@ -33,12 +32,11 @@ container_push(
 
 pkg_tar(
     name = "bin_rpcserver",
-    srcs = [
-        "//cmd/heim-rpcserver",
-        "@grpc_health_probe//file",
-    ],
+    files = {
+        "//cmd/heim-rpcserver:linux": "/usr/local/bin/heim-rpcserver",
+        "@grpc_health_probe//file": "/usr/local/bin/grpc_health_probe",
+    },
     mode = "0755",
-    package_dir = "/usr/local/bin",
 )
 
 container_image(
@@ -63,11 +61,10 @@ container_push(
 
 pkg_tar(
     name = "bin_dashboard",
-    srcs = [
-        "//cmd/heim-dashboard",
-    ],
+    files = {
+        "//cmd/heim-dashboard:linux": "/usr/local/bin/heim-dashboard"
+    },
     mode = "0755",
-    package_dir = "/usr/local/bin",
 )
 
 container_image(
@@ -92,9 +89,10 @@ container_push(
 
 pkg_tar(
     name = "bin_ctl",
-    srcs = ["//cmd/heimctl"],
+    files = {
+        "//cmd/heimctl:linux": "/usr/local/bin/heimctl"
+    },
     mode = "0755",
-    package_dir = "/usr/local/bin",
 )
 
 container_image(


### PR DESCRIPTION
container: Force building the container for linux/amd64 regardless of host OS

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/32).
* __->__ #32
* #31
* #30
* #29
