### PR TITLE
cmd/release: Authenticate when retrieving the image detail

### DIFF
--- a/pkg/cmd/release/container.go
+++ b/pkg/cmd/release/container.go
@@ -43,7 +43,7 @@ func containerReleaseCmd(repository, sha256File, tag string, override bool) erro
 	if err != nil {
 		return xerrors.Errorf(": %w", err)
 	}
-	desc, err := remote.Image(ref)
+	desc, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return xerrors.Errorf(": %w", err)
 	}


### PR DESCRIPTION
cmd/release: Authenticate when retrieving the image detail

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/43).
* __->__ #43
* #42
