### PR TITLE
k8s/controllers: Run the informer for third party client

### DIFF
--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -193,7 +193,7 @@ func (m *mainProcess) startWorkers() (fsm.State, error) {
 	coreSharedInformerFactory := kubeinformers.NewSharedInformerFactory(m.coreClient, 30*time.Second)
 	factory := client.NewInformerFactory(m.client, client.NewInformerCache(), metav1.NamespaceAll, 30*time.Second)
 
-	c, err := controllers.NewProxyController(factory, coreSharedInformerFactory, m.coreClient, m.client, m.thirdPartyClient)
+	c, err := controllers.NewProxyController(m.ctx, factory, coreSharedInformerFactory, m.coreClient, m.client, m.thirdPartyClient)
 	if err != nil {
 		return fsm.UnknownState, err
 	}

--- a/pkg/k8s/controllers/proxy_controller.go
+++ b/pkg/k8s/controllers/proxy_controller.go
@@ -85,6 +85,7 @@ type ProxyController struct {
 }
 
 func NewProxyController(
+	ctx context.Context,
 	sharedInformerFactory *client.InformerFactory,
 	coreSharedInformerFactory kubeinformers.SharedInformerFactory,
 	coreClient kubernetes.Interface,
@@ -148,6 +149,7 @@ func NewProxyController(
 		coreosInformer := thirdpartyclient.NewCoreosComV1Informer(f.Cache(), thirdPartyClientSet.CoreosComV1, metav1.NamespaceAll, 30*time.Second)
 		c.pmLister = coreosInformer.PodMonitorLister()
 		c.pmListerSynced = coreosInformer.PodMonitorInformer().HasSynced
+		f.Run(ctx)
 	}
 
 	return c, nil
@@ -1130,7 +1132,7 @@ func (c *ProxyController) createOrUpdateCertificate(ctx context.Context, lp *Hei
 }
 
 func (c *ProxyController) createOrUpdateServiceMonitor(ctx context.Context, lp *HeimdallrProxy, serviceMonitor *monitoringv1.ServiceMonitor) error {
-	sm, err := c.thirdPartyClientSet.CoreosComV1.GetServiceMonitor(ctx, serviceMonitor.Namespace, serviceMonitor.Namespace, metav1.GetOptions{})
+	sm, err := c.thirdPartyClientSet.CoreosComV1.GetServiceMonitor(ctx, serviceMonitor.Namespace, serviceMonitor.Name, metav1.GetOptions{})
 	if err != nil && apierrors.IsNotFound(err) {
 		lp.ControlObject(serviceMonitor)
 

--- a/pkg/k8s/controllers/runner_test.go
+++ b/pkg/k8s/controllers/runner_test.go
@@ -624,7 +624,7 @@ func newProxyControllerTestRunner(t *testing.T) *proxyControllerTestRunner {
 		},
 	}
 
-	c, err := NewProxyController(f.sharedInformerFactory, f.coreSharedInformerFactory, f.coreClient, &f.client.Set, nil)
+	c, err := NewProxyController(context.Background(), f.sharedInformerFactory, f.coreSharedInformerFactory, f.coreClient, &f.client.Set, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
k8s/controllers: Run the informer for third party client

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/54).
* __->__ #54
* #53
