### PR TITLE
rules/go: Fix the bug that GOARCH could not be specified

### DIFF
--- a/build/rules/go/util.bzl
+++ b/build/rules/go/util.bzl
@@ -21,7 +21,7 @@ def go_binary_for_container(**kwargs):
 
         go_binary(
             name = platform,
-            goarch = "amd64",
-            goos = "linux",
+            goarch = arch,
+            goos = os,
             **kwargs
         )


### PR DESCRIPTION
rules/go: Fix the bug that GOARCH could not be specified

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/79).
* #80
* __->__ #79