### PR TITLE
k8s/kind: Fix the bug that rename the image name of the container

### DIFF
--- a/pkg/k8s/kind/cluster.go
+++ b/pkg/k8s/kind/cluster.go
@@ -220,7 +220,7 @@ func (c *Cluster) LoadImageFiles(images ...*ContainerImageFile) error {
 				"ctr", "-n", "k8s.io",
 				"images", "tag",
 				"--force",
-				"docker.io/"+image.repoTags,
+				image.repoTags,
 				fmt.Sprintf("%s:%s", image.Repository, image.Tag),
 			)
 			cmd.Stdout = os.Stdout


### PR DESCRIPTION
k8s/kind: Fix the bug that rename the image name of the container

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/heimdallr/pull/80).
* __->__ #80
* #79